### PR TITLE
Django 1.8 compatible ModelAdmin.get_urls

### DIFF
--- a/modelclone/admin.py
+++ b/modelclone/admin.py
@@ -46,11 +46,19 @@ class ClonableModelAdmin(ModelAdmin):
             self.model._meta.app_label,
             getattr(self.model._meta, 'module_name', getattr(self.model._meta, 'model_name', '')))
 
-        new_urlpatterns = [
-            url(r'^(.+)/change/clone/$',
-                self.admin_site.admin_view(self.clone_view),
-                name=url_name)
-        ]
+        if VERSION[1] < 9:
+            from django.conf.urls import patterns
+            new_urlpatterns = patterns('',
+                url(r'^(.+)/clone/$',
+                    self.admin_site.admin_view(self.clone_view),
+                    name=url_name)
+                )
+        else:
+            new_urlpatterns = [
+                url(r'^(.+)/change/clone/$',
+                    self.admin_site.admin_view(self.clone_view),
+                    name=url_name)
+            ]
 
         original_urlpatterns = super(ClonableModelAdmin, self).get_urls()
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -85,7 +85,10 @@ class ClonableModelAdminTests(WebTest):
 
     def test_clone_view_url_name(self):
         post_id = self.post.id
-        expected_url = '/admin/posts/post/{0}/change/clone/'.format(post_id)
+        if django.VERSION[1] < 9:
+            expected_url = '/admin/posts/post/{0}/clone/'.format(post_id)
+        else:
+            expected_url = '/admin/posts/post/{0}/change/clone/'.format(post_id)
 
         assert reverse('admin:posts_post_clone', args=(post_id,)) == expected_url
 


### PR DESCRIPTION
This replaces code what was removed in bb3a835.

Closes #26.