### PR TITLE
Adding support for Django 4.0+ in a non-breaking manner consistent with the way Django 1.7+ support was handled.

### DIFF
--- a/modelclone/admin.py
+++ b/modelclone/admin.py
@@ -5,10 +5,17 @@ try:
 except ImportError:
     # django < 1.7
     from django.contrib.admin.util import unquote
-from django.conf.urls import url
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext as _
-from django.utils.translation import ugettext_lazy as lazy
+try:
+    from django.urls import re_path as url
+    from django.utils.encoding import force_str as force_text
+    from django.utils.translation import gettext as _
+    from django.utils.translation import gettext_lazy as lazy
+except ImportError:
+    # django < 4.0
+    from django.conf.urls import url
+    from django.utils.encoding import force_text
+    from django.utils.translation import ugettext as _
+    from django.utils.translation import ugettext_lazy as lazy
 from django.utils.html import escape
 from django.forms.models import model_to_dict
 from django.forms.formsets import all_valid


### PR DESCRIPTION
Adding support for Django 4.0+ in a non-breaking manner consistent with the way Django 1.7+ support was handled. 

(Django 4.0+ depreciated conf.urls.url,  utils.encoding.force_text, utils.translation.ugettext, and utils.translation.ugettext_lazy. These functions were replaced with re_path, force_str, gettext, and gettext_lazy.) 

Source: https://docs.djangoproject.com/en/5.0/releases/4.0/#features-removed-in-4-0